### PR TITLE
Add Docker client health check

### DIFF
--- a/controllers/result.go
+++ b/controllers/result.go
@@ -3,7 +3,10 @@
 
 package controllers
 
-import "github.com/waflab/waflab/object"
+import (
+	"github.com/waflab/waflab/docker"
+	"github.com/waflab/waflab/object"
+)
 
 func (c *ApiController) GetResult() {
 	testsetId := c.Input().Get("testsetId")
@@ -11,5 +14,14 @@ func (c *ApiController) GetResult() {
 	typ := c.Input().Get("type")
 
 	c.Data["json"] = object.GetResult(testsetId, testcaseId, typ)
+	c.ServeJSON()
+}
+
+func (c *ApiController) GetDockerHealth() {
+	c.Data["json"] = &struct {
+		Health bool `json:"health"`
+	}{
+		docker.GetMasterHealth(),
+	}
 	c.ServeJSON()
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -40,4 +40,5 @@ func initAPI() {
 	beego.Router("/api/delete-testcase", &controllers.ApiController{}, "POST:DeleteTestcase")
 
 	beego.Router("/api/get-result", &controllers.ApiController{}, "GET:GetResult")
+	beego.Router("/api/get-docker-health", &controllers.ApiController{}, "GET:GetDockerHealth")
 }

--- a/web/src/backend/ResultBackend.js
+++ b/web/src/backend/ResultBackend.js
@@ -1,8 +1,16 @@
 import * as Setting from "../Setting";
 
 export function getResult(testsetId, testcaseId, type) {
-  return fetch(`${Setting.ServerUrl}/api/get-result?testsetId=${testsetId}&testcaseId=${testcaseId}&type=${type}`, {
+  return fetch(`${Setting.ServerUrl}/api/get-docker-health`, {
     method: "GET",
     credentials: "include"
-  }).then(res => res.json());
+  }).then(res => {
+    if (!res.json()["health"]) {
+      throw new Error("Backend docker is not healthy")
+    }
+  })
+    .then(() => fetch(`${Setting.ServerUrl}/api/get-result?testsetId=${testsetId}&testcaseId=${testcaseId}&type=${type}`, {
+      method: "GET",
+      credentials: "include"
+    })).then(res => res.json())
 }


### PR DESCRIPTION
This add following functionalities
 * allow the backend to run without Docker Engine
 * add /api/get-docker-health to check Docker's health at backend
 * call /api/get-docker-health everytime before calling /api/get-result at frontend