### PR TITLE
Migrate WAFbench docker image 

### DIFF
--- a/docker/master.go
+++ b/docker/master.go
@@ -121,7 +121,7 @@ func MakeMaster(numContainer int) *Master {
 		return &m
 	}
 
-	reader, err := cli.ImagePull(ctx, "docker.io/olament/wafbench", types.ImagePullOptions{})
+	reader, err := cli.ImagePull(ctx, "docker.io/waflab/wafbench", types.ImagePullOptions{})
 	if err != nil {
 		panic(err)
 	}

--- a/docker/worker.go
+++ b/docker/worker.go
@@ -135,7 +135,7 @@ func MakeWorker(master *Master, cli *client.Client, ctx context.Context, port st
 	// create a new container if there is not one already
 	if containerID == "" {
 		resp, err := cli.ContainerCreate(ctx, &container.Config{
-			Image:      "olament/wafbench",
+			Image:      "waflab/wafbench",
 			WorkingDir: "/WAFBench/ftw_compatible_tool",
 			ExposedPorts: nat.PortSet{
 				"5000": struct{}{},


### PR DESCRIPTION
Now we use WAFBench image under [WAFLab Organization](https://hub.docker.com/u/waflab)