### PR TITLE
Content-Length is now an Integer instead of String

### DIFF
--- a/autogen/payload/compose.go
+++ b/autogen/payload/compose.go
@@ -6,7 +6,6 @@ package payload
 import (
 	"fmt"
 	"net/url"
-	"strconv"
 
 	"github.com/waflab/waflab/test"
 )
@@ -50,7 +49,7 @@ func composeFile(payload *test.Input, name, filename, content string) {
 	for _, d := range payload.Data {
 		length += len(d) + 2 // including /r/n
 	}
-	payload.Headers["Content-Length"] = strconv.Itoa(length - 4) // excluding trailing \r\n\r\n
+	payload.Headers["Content-Length"] = length - 4 // excluding trailing \r\n\r\n
 }
 
 // setURI set the Uri entry in test.Input

--- a/autogen/payload/request.go
+++ b/autogen/payload/request.go
@@ -78,7 +78,7 @@ func addQueryString(value, index string, payload *test.Input) error {
 func addRequestBody(value, index string, payload *test.Input) error {
 	payload.Method = "POST"
 	payload.Data = append(payload.Data, value)
-	composeHeader(payload, "Content-Length", strconv.Itoa(len(payload.Data[0])))
+	payload.Headers["Content-Length"] = len(payload.Data[0])
 	composeHeader(payload, "Content-Type", "application/x-www-form-urlencoded")
 	return nil
 }
@@ -148,7 +148,7 @@ func addXML(value, index string, payload *test.Input) error {
 	payload.Data = []string{string(content)}
 	payload.Method = "POST"
 	payload.Headers["Content-Type"] = "text/xml"
-	payload.Headers["Content-Length"] = strconv.Itoa(len(string(content)))
+	payload.Headers["Content-Length"] = len(string(content))
 
 	return nil
 }

--- a/autogen/yaml/construct.go
+++ b/autogen/yaml/construct.go
@@ -38,7 +38,7 @@ func DefaultStage() *test.Stage {
 			Protocol:   "http",
 			Uri:        "/",
 			Version:    "HTTP/1.0",
-			Headers:    map[string]string{},
+			Headers:    map[string]interface{}{},
 		},
 		Output: &test.Output{
 			Status:        []int{200},

--- a/object/sender.go
+++ b/object/sender.go
@@ -58,7 +58,7 @@ func getWafResult(testset *Testset, testcase *Testcase) *Result {
 	return nil
 }
 
-func sendRaw(method string, host string, uri string, query string, userAgent string, headers map[string]string) (*http.Response, error) {
+func sendRaw(method string, host string, uri string, query string, userAgent string, headers map[string]interface{}) (*http.Response, error) {
 	client := &http.Client{}
 	//host = "http://127.0.0.1:8888"
 	url := host + uri + query
@@ -75,9 +75,9 @@ func sendRaw(method string, host string, uri string, query string, userAgent str
 		// https://github.com/golang/go/issues/7682
 		if k == "Host" {
 			req.Host = ""
-			req.Header.Add(k, v)
+			req.Header.Add(k, v.(string))
 		} else {
-			req.Header.Add(k, v)
+			req.Header.Add(k, v.(string))
 		}
 	}
 

--- a/rule/rulefile.go
+++ b/rule/rulefile.go
@@ -93,7 +93,7 @@ func (rf *Rulefile) syncParanoiaLevels() {
 func getUserAgent(tf *test.Testfile) string {
 	headers := tf.Tests[0].Stages[0].Stage.Input.Headers
 	if userAgent, ok := headers["User-Agent"]; ok {
-		return userAgent
+		return userAgent.(string)
 	} else {
 		return ""
 	}

--- a/test/testfile.go
+++ b/test/testfile.go
@@ -57,18 +57,18 @@ func (data *DataSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 type Input struct {
-	SaveCookie     bool              `yaml:"save_cookie,omitempty"`
-	StopMagic      bool              `yaml:"stop_magic,omitempty"`
-	DestAddr       string            `yaml:"dest_addr"`
-	Method         string            `yaml:"method"`
-	Port           int               `yaml:"port"`
-	Protocol       string            `yaml:"protocol"`
-	Uri            string            `yaml:"uri"`
-	Version        string            `yaml:"version"`
-	Headers        map[string]string `yaml:"headers,omitempty"`
-	Data           DataSlice         `yaml:"data,omitempty"`
-	EncodedRequest string            `yaml:"encoded_request,omitempty"`
-	RawRequest     string            `yaml:"raw_request,omitempty"`
+	SaveCookie     bool                   `yaml:"save_cookie,omitempty"`
+	StopMagic      bool                   `yaml:"stop_magic,omitempty"`
+	DestAddr       string                 `yaml:"dest_addr"`
+	Method         string                 `yaml:"method"`
+	Port           int                    `yaml:"port"`
+	Protocol       string                 `yaml:"protocol"`
+	Uri            string                 `yaml:"uri"`
+	Version        string                 `yaml:"version"`
+	Headers        map[string]interface{} `yaml:"headers,omitempty"`
+	Data           DataSlice              `yaml:"data,omitempty"`
+	EncodedRequest string                 `yaml:"encoded_request,omitempty"`
+	RawRequest     string                 `yaml:"raw_request,omitempty"`
 }
 
 type Output struct {


### PR DESCRIPTION
This PR changes the type of payload header from map[string]string to map[string]interface{} to allow passing non-string content (ex. Content-Length) to request's headers. 